### PR TITLE
change_reference added for def_change_log

### DIFF
--- a/Controllers/DefChangeController.py
+++ b/Controllers/DefChangeController.py
@@ -31,7 +31,7 @@ class DefChangeController(Resource):
 
 
     def get_audit_list(self,id_list=None,table_name=None):
-        sql = "select distinct id,table_name,change_type,\
+        sql = "select distinct id,table_name,change_type,change_reference,\
                                 date_of_change,maker,maker_comment,checker,checker_comment,status,date_of_checking\
                                  from def_change_log where 1"
         if id_list == "id" or ((id_list is None or id_list == 'undefined') and (table_name is None or table_name=='undefined')):

--- a/Helpers/AuditHelper.py
+++ b/Helpers/AuditHelper.py
@@ -27,8 +27,8 @@ class AuditHelper(object):
 
     def audit_delete(self,data,id):
         audit_info=data['audit_info']
-        sql="insert into def_change_log(id,table_name,change_type,maker_comment,status) values(%s,%s,%s,%s,%s)"
-        res=self.db.transact(sql,(id,audit_info['table_name'],audit_info['change_type'],audit_info['comment'],'PENDING'))
+        sql="insert into def_change_log(id,table_name,change_type,maker_comment,status,change_reference) values(%s,%s,%s,%s,%s,%s)"
+        res=self.db.transact(sql,(id,audit_info['table_name'],audit_info['change_type'],audit_info['comment'],'PENDING',audit_info['change_reference']))
         self.update_approval_status(table_name=audit_info['table_name'], id=id, dml_allowed='N')
         self.db.commit()
 
@@ -47,9 +47,9 @@ class AuditHelper(object):
 
             if old_val != new_val and col not in ('dml_allowed','in_use'):
                 print(col, old_val, new_val)
-                sql="insert into def_change_log(id,table_name,field_name,old_val,new_val,change_type,maker_comment,status)\
-                    values(%s,%s,%s,%s,%s,%s,%s,%s)"
-                params=(id,audit_info['table_name'],col,old_val,new_val,audit_info['change_type'],audit_info['comment'],'PENDING')
+                sql="insert into def_change_log(id,table_name,field_name,old_val,new_val,change_type,maker_comment,status,change_reference)\
+                    values(%s,%s,%s,%s,%s,%s,%s,%s,%s)"
+                params=(id,audit_info['table_name'],col,old_val,new_val,audit_info['change_type'],audit_info['comment'],'PENDING',audit_info['change_reference'])
                 res=self.db.transact(sql,params)
                 def_change_insert+=1
 
@@ -62,8 +62,8 @@ class AuditHelper(object):
 
     def audit_insert(self, data, id):
         audit_info = data['audit_info']
-        sql = "insert into def_change_log(id,table_name,change_type,maker_comment,status) values(%s,%s,%s,%s,%s)"
-        res = self.db.transact(sql, (id, audit_info['table_name'], audit_info['change_type'], audit_info['comment'], 'PENDING'))
+        sql = "insert into def_change_log(id,table_name,change_type,maker_comment,status,change_reference) values(%s,%s,%s,%s,%s,%s)"
+        res = self.db.transact(sql, (id, audit_info['table_name'], audit_info['change_type'], audit_info['comment'], 'PENDING',audit_info['change_reference']))
         print("this should be id of the record inserted..what it actually is ",res)
         self.update_approval_status(table_name=audit_info['table_name'],id=id, dml_allowed='N',in_use='N')
         self.db.commit()


### PR DESCRIPTION
change_reference has been added for def_change_log to record meaningful reference
at the dml audit log stage. This will help to reduce load on databse query to fetch meaningful references for display in audit history modals.